### PR TITLE
Feature/r4y0bq prevent double approve and create brokerage

### DIFF
--- a/LBH.AdultSocialCare.Api/V1/Boundary/ResidentialCareBrokerageBoundary/Response/ResidentialCareBrokerageInfoResponse.cs
+++ b/LBH.AdultSocialCare.Api/V1/Boundary/ResidentialCareBrokerageBoundary/Response/ResidentialCareBrokerageInfoResponse.cs
@@ -8,7 +8,7 @@ namespace LBH.AdultSocialCare.Api.V1.Boundary.ResidentialCareBrokerageBoundary.R
         /// <summary>
         /// Gets or sets the Residential Care Brokerage Id
         /// </summary>
-        public Guid ResidentialCareBrokerageId { get; set; }
+        public Guid Id { get; set; }
 
         /// <summary>
         /// Gets or sets the Residential Care Package Id

--- a/LBH.AdultSocialCare.Api/V1/BusinessRules/PackageStatusTransitions.cs
+++ b/LBH.AdultSocialCare.Api/V1/BusinessRules/PackageStatusTransitions.cs
@@ -1,0 +1,25 @@
+using LBH.AdultSocialCare.Api.V1.AppConstants;
+using LBH.AdultSocialCare.Api.V1.Extensions;
+
+namespace LBH.AdultSocialCare.Api.V1.BusinessRules
+{
+    public static class PackageStatusTransitions
+    {
+        /// <summary>
+        /// Returns true if transition from the currentStatusId to a newStatusId is possible, otherwise, false.
+        /// </summary>
+        public static bool CanChangeStatus(int currentStatusId, int newStatusId)
+        {
+            switch (newStatusId)
+            {
+                case ApprovalHistoryConstants.PackageApprovedId:
+                    return currentStatusId.NotIn(
+                        ApprovalHistoryConstants.PackageApprovedId,
+                        ApprovalHistoryConstants.PackageBrokeredId);
+
+                default:
+                    return true;
+            }
+        }
+    }
+}

--- a/LBH.AdultSocialCare.Api/V1/Domain/ResidentialCareBrokerageDomains/ResidentialCareBrokerageInfoDomain.cs
+++ b/LBH.AdultSocialCare.Api/V1/Domain/ResidentialCareBrokerageDomains/ResidentialCareBrokerageInfoDomain.cs
@@ -11,7 +11,7 @@ namespace LBH.AdultSocialCare.Api.V1.Domain.ResidentialCareBrokerageDomains
         /// <summary>
         /// Gets or sets the Residential Care Brokerage Id
         /// </summary>
-        public Guid ResidentialCareBrokerageId { get; set; }
+        public Guid Id { get; set; }
 
         /// <summary>
         /// Gets or sets the Residential Care Package Id

--- a/LBH.AdultSocialCare.Api/V1/Extensions/IntExtensions.cs
+++ b/LBH.AdultSocialCare.Api/V1/Extensions/IntExtensions.cs
@@ -1,0 +1,26 @@
+using System.Linq;
+
+namespace LBH.AdultSocialCare.Api.V1.Extensions
+{
+    /// <summary>
+    /// Provides extension methods for <see cref="int"/>.
+    /// </summary>
+    public static class IntExtensions
+    {
+        /// <summary>
+        /// Returns true if the given value exists in the list, otherwise false.
+        /// </summary>
+        public static bool In(this int value, params int[] list)
+        {
+            return list.Contains(value);
+        }
+
+        /// <summary>
+        /// Returns true if the given value doesn't exists in the list, otherwise false.
+        /// </summary>
+        public static bool NotIn(this int value, params int[] list)
+        {
+            return !value.In(list);
+        }
+    }
+}

--- a/LBH.AdultSocialCare.Api/V1/Gateways/NursingCareBrokerageGateways/NursingCareBrokerageGateway.cs
+++ b/LBH.AdultSocialCare.Api/V1/Gateways/NursingCareBrokerageGateways/NursingCareBrokerageGateway.cs
@@ -122,6 +122,9 @@ namespace LBH.AdultSocialCare.Api.V1.Gateways.NursingCareBrokerageGateways
             {
                 throw new EntityNotFoundException($"Couldn't find nursing care package {nursingCarePackageId.ToString()}");
             }
+
+            if (nursingPackage.StageId == stageId) return false;
+
             nursingPackage.StageId = stageId;
             if (PackageStageConstants.BrokerageAssignedId == stageId)
                 nursingPackage.AssignedUserId = new Guid("aee45700-af9b-4ab5-bb43-535adbdcfb84");

--- a/LBH.AdultSocialCare.Api/V1/Gateways/ResidentialCareBrokerageGateways/ResidentialCareBrokerageGateway.cs
+++ b/LBH.AdultSocialCare.Api/V1/Gateways/ResidentialCareBrokerageGateways/ResidentialCareBrokerageGateway.cs
@@ -5,7 +5,6 @@ using LBH.AdultSocialCare.Api.V1.Infrastructure;
 using LBH.AdultSocialCare.Api.V1.Infrastructure.Entities.ResidentialCareBrokerage;
 using Microsoft.EntityFrameworkCore;
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using LBH.AdultSocialCare.Api.V1.AppConstants;
 
@@ -72,6 +71,9 @@ namespace LBH.AdultSocialCare.Api.V1.Gateways.ResidentialCareBrokerageGateways
             {
                 throw new EntityNotFoundException($"Couldn't find residential care package {residentialCarePackageId.ToString()}");
             }
+
+            if (residentialPackage.StageId == stageId) return false;
+
             residentialPackage.StageId = stageId;
             if (PackageStageConstants.BrokerageAssignedId == stageId)
                 residentialPackage.AssignedUserId = new Guid("aee45700-af9b-4ab5-bb43-535adbdcfb84");

--- a/LBH.AdultSocialCare.Api/V1/Gateways/ResidentialCareBrokerageGateways/ResidentialCareBrokerageGateway.cs
+++ b/LBH.AdultSocialCare.Api/V1/Gateways/ResidentialCareBrokerageGateways/ResidentialCareBrokerageGateway.cs
@@ -53,6 +53,7 @@ namespace LBH.AdultSocialCare.Api.V1.Gateways.ResidentialCareBrokerageGateways
 
             return new ResidentialCareBrokerageInfoDomain
             {
+                Id = residentialCarePackage.ResidentialCareBrokerageInfo?.Id ?? Guid.Empty,
                 ResidentialCarePackageId = residentialCarePackageId,
                 ResidentialCarePackage = residentialCarePackage.ToDomain(),
                 ResidentialCore = residentialCarePackage.ResidentialCareBrokerageInfo?.ResidentialCore ?? 0,

--- a/LBH.AdultSocialCare.Api/V1/UseCase/NursingCareBrokerageUseCase/Concrete/CreateNursingCareBrokerageUseCase.cs
+++ b/LBH.AdultSocialCare.Api/V1/UseCase/NursingCareBrokerageUseCase/Concrete/CreateNursingCareBrokerageUseCase.cs
@@ -1,8 +1,7 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
+using Common.Exceptions.CustomExceptions;
 using LBH.AdultSocialCare.Api.V1.Boundary.NursingCareBrokerageBoundary.Response;
 using LBH.AdultSocialCare.Api.V1.Domain.NursingCareBrokerageDomains;
 using LBH.AdultSocialCare.Api.V1.Domain.NursingCarePackageDomains;
@@ -28,6 +27,13 @@ namespace LBH.AdultSocialCare.Api.V1.UseCase.NursingCareBrokerageUseCase.Concret
 
         public async Task<NursingCareBrokerageInfoResponse> ExecuteAsync(NursingCareBrokerageInfoCreationDomain nursingCareBrokerageInfoCreationDomain)
         {
+            var brokerage = await _nursingCareBrokerageGateway.GetAsync(nursingCareBrokerageInfoCreationDomain.NursingCarePackageId).ConfigureAwait(false);
+
+            if (brokerage.NursingCareBrokerageId != Guid.Empty)
+            {
+                throw new ApiException($"A brokerage for nursing care package {nursingCareBrokerageInfoCreationDomain.NursingCarePackageId} already exists");
+            }
+
             var nursingCareBrokerageInfoEntity = nursingCareBrokerageInfoCreationDomain.ToDb();
             var res = await _nursingCareBrokerageGateway.CreateAsync(nursingCareBrokerageInfoEntity).ConfigureAwait(false);
             if (res == null) return null;

--- a/LBH.AdultSocialCare.Api/V1/UseCase/NursingCareBrokerageUseCase/Concrete/SetStageToNursingCarePackageUseCase.cs
+++ b/LBH.AdultSocialCare.Api/V1/UseCase/NursingCareBrokerageUseCase/Concrete/SetStageToNursingCarePackageUseCase.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using LBH.AdultSocialCare.Api.V1.AppConstants;
 using LBH.AdultSocialCare.Api.V1.Domain.NursingCareBrokerageDomains;
@@ -29,19 +27,24 @@ namespace LBH.AdultSocialCare.Api.V1.UseCase.NursingCareBrokerageUseCase.Concret
 
         public async Task<bool> UpdatePackage(Guid nursingCarePackageId, int stageId)
         {
-            var result = await _nursingCareBrokerageGateway.SetStage(nursingCarePackageId, stageId).ConfigureAwait(false);
-            var userId = new Guid("1f825b5f-5c65-41fb-8d9e-9d36d78fd6d8");
-            var user = await _usersGateway.GetAsync(userId).ConfigureAwait(false);
-            var stageText = PackageStageConstants.GetStageText(stageId);
-            var newPackageHistory = new NursingCareApprovalHistoryDomain()
+            var stageChanged = await _nursingCareBrokerageGateway.SetStage(nursingCarePackageId, stageId).ConfigureAwait(false);
+
+            if (stageChanged)
             {
-                NursingCarePackageId = nursingCarePackageId,
-                ApprovedDate = DateTimeOffset.Now,
-                LogText = $"{stageText} {user.Name}",
-                UserId = user.Id
-            };
-            await _nursingCareApprovalHistoryGateway.CreateAsync(newPackageHistory.ToDb()).ConfigureAwait(false);
-            return result;
+                var userId = new Guid("1f825b5f-5c65-41fb-8d9e-9d36d78fd6d8");
+                var user = await _usersGateway.GetAsync(userId).ConfigureAwait(false);
+                var stageText = PackageStageConstants.GetStageText(stageId);
+                var newPackageHistory = new NursingCareApprovalHistoryDomain()
+                {
+                    NursingCarePackageId = nursingCarePackageId,
+                    ApprovedDate = DateTimeOffset.Now,
+                    LogText = $"{stageText} {user.Name}",
+                    UserId = user.Id
+                };
+                await _nursingCareApprovalHistoryGateway.CreateAsync(newPackageHistory.ToDb()).ConfigureAwait(false);
+            }
+
+            return stageChanged;
         }
     }
 }

--- a/LBH.AdultSocialCare.Api/V1/UseCase/NursingCareUseCases/Concrete/ChangeStatusNursingCarePackageUseCase.cs
+++ b/LBH.AdultSocialCare.Api/V1/UseCase/NursingCareUseCases/Concrete/ChangeStatusNursingCarePackageUseCase.cs
@@ -1,15 +1,15 @@
 using System;
 using System.Threading.Tasks;
+using Common.Exceptions.CustomExceptions;
 using LBH.AdultSocialCare.Api.V1.AppConstants;
 using LBH.AdultSocialCare.Api.V1.Boundary.NursingCarePackageBoundary.Response;
-using LBH.AdultSocialCare.Api.V1.Domain.NursingCareApprovePackageDomains;
 using LBH.AdultSocialCare.Api.V1.Domain.NursingCareBrokerageDomains;
 using LBH.AdultSocialCare.Api.V1.Domain.NursingCarePackageDomains;
+using LBH.AdultSocialCare.Api.V1.Extensions;
 using LBH.AdultSocialCare.Api.V1.Factories;
 using LBH.AdultSocialCare.Api.V1.Gateways.Interfaces;
 using LBH.AdultSocialCare.Api.V1.Gateways.NursingCareApprovalHistoryGateways;
 using LBH.AdultSocialCare.Api.V1.Gateways.NursingCarePackageGateways;
-using LBH.AdultSocialCare.Api.V1.UseCase.Interfaces;
 using LBH.AdultSocialCare.Api.V1.UseCase.NursingCareUseCases.Interfaces;
 
 namespace LBH.AdultSocialCare.Api.V1.UseCase.NursingCareUseCases.Concrete
@@ -30,6 +30,15 @@ namespace LBH.AdultSocialCare.Api.V1.UseCase.NursingCareUseCases.Concrete
 
         public async Task<NursingCarePackageResponse> UpdateAsync(Guid nursingCarePackageId, int statusId, string requestMoreInformation = null)
         {
+            var package = await _gateway.GetAsync(nursingCarePackageId).ConfigureAwait(false);
+
+            if (!CanChangeStatus(package, statusId))
+            {
+                throw new ApiException(
+                    "Cannot change status of nursing care package",
+                    detail: $"Cannot set status of the package {nursingCarePackageId} to '{ApprovalHistoryConstants.GetLogText(statusId)}' as it is already in status '{ApprovalHistoryConstants.GetLogText(package.StatusId)}'");
+            }
+
             var nursingCarePackageDomain = await _gateway.ChangeStatusAsync(nursingCarePackageId, statusId).ConfigureAwait(false);
             var userId = new Guid("1f825b5f-5c65-41fb-8d9e-9d36d78fd6d8");
             var user = await _usersGateway.GetAsync(userId).ConfigureAwait(false);
@@ -47,6 +56,18 @@ namespace LBH.AdultSocialCare.Api.V1.UseCase.NursingCareUseCases.Concrete
             return nursingCarePackageDomain.ToResponse();
         }
 
+        private static bool CanChangeStatus(NursingCarePackageDomain package, int statusId)
+        {
+            switch (statusId)
+            {
+                case ApprovalHistoryConstants.PackageApprovedId:
+                    return package.StatusId.NotIn(
+                        ApprovalHistoryConstants.PackageApprovedId,
+                        ApprovalHistoryConstants.ApprovedForCommercialId);
 
+                default:
+                    return true;
+            }
+        }
     }
 }

--- a/LBH.AdultSocialCare.Api/V1/UseCase/NursingCareUseCases/Concrete/ChangeStatusNursingCarePackageUseCase.cs
+++ b/LBH.AdultSocialCare.Api/V1/UseCase/NursingCareUseCases/Concrete/ChangeStatusNursingCarePackageUseCase.cs
@@ -3,9 +3,8 @@ using System.Threading.Tasks;
 using Common.Exceptions.CustomExceptions;
 using LBH.AdultSocialCare.Api.V1.AppConstants;
 using LBH.AdultSocialCare.Api.V1.Boundary.NursingCarePackageBoundary.Response;
+using LBH.AdultSocialCare.Api.V1.BusinessRules;
 using LBH.AdultSocialCare.Api.V1.Domain.NursingCareBrokerageDomains;
-using LBH.AdultSocialCare.Api.V1.Domain.NursingCarePackageDomains;
-using LBH.AdultSocialCare.Api.V1.Extensions;
 using LBH.AdultSocialCare.Api.V1.Factories;
 using LBH.AdultSocialCare.Api.V1.Gateways.Interfaces;
 using LBH.AdultSocialCare.Api.V1.Gateways.NursingCareApprovalHistoryGateways;
@@ -32,7 +31,7 @@ namespace LBH.AdultSocialCare.Api.V1.UseCase.NursingCareUseCases.Concrete
         {
             var package = await _gateway.GetAsync(nursingCarePackageId).ConfigureAwait(false);
 
-            if (!CanChangeStatus(package, statusId))
+            if (!PackageStatusTransitions.CanChangeStatus(package.StatusId, statusId))
             {
                 throw new ApiException(
                     "Cannot change status of nursing care package",
@@ -54,20 +53,6 @@ namespace LBH.AdultSocialCare.Api.V1.UseCase.NursingCareUseCases.Concrete
             };
             await _nursingCareApprovalHistoryGateway.CreateAsync(newPackageHistory.ToDb()).ConfigureAwait(false);
             return nursingCarePackageDomain.ToResponse();
-        }
-
-        private static bool CanChangeStatus(NursingCarePackageDomain package, int statusId)
-        {
-            switch (statusId)
-            {
-                case ApprovalHistoryConstants.PackageApprovedId:
-                    return package.StatusId.NotIn(
-                        ApprovalHistoryConstants.PackageApprovedId,
-                        ApprovalHistoryConstants.ApprovedForCommercialId);
-
-                default:
-                    return true;
-            }
         }
     }
 }

--- a/LBH.AdultSocialCare.Api/V1/UseCase/ResidentialCareBrokerageUseCase/Concrete/CreateResidentialCareBrokerageUseCase.cs
+++ b/LBH.AdultSocialCare.Api/V1/UseCase/ResidentialCareBrokerageUseCase/Concrete/CreateResidentialCareBrokerageUseCase.cs
@@ -1,7 +1,6 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
+using Common.Exceptions.CustomExceptions;
 using LBH.AdultSocialCare.Api.V1.Boundary.ResidentialCareBrokerageBoundary.Response;
 using LBH.AdultSocialCare.Api.V1.Domain.ResidentialCareBrokerageDomains;
 using LBH.AdultSocialCare.Api.V1.Factories;
@@ -21,6 +20,13 @@ namespace LBH.AdultSocialCare.Api.V1.UseCase.ResidentialCareBrokerageUseCase.Con
 
         public async Task<ResidentialCareBrokerageInfoResponse> ExecuteAsync(ResidentialCareBrokerageInfoCreationDomain residentialCareBrokerageInfoCreationDomain)
         {
+            var brokerageInfo = await _residentialCareBrokerageGateway.GetAsync(residentialCareBrokerageInfoCreationDomain.ResidentialCarePackageId).ConfigureAwait(false);
+
+            if (brokerageInfo.Id != Guid.Empty)
+            {
+                throw new ApiException($"A brokerage for residential care package {residentialCareBrokerageInfoCreationDomain.ResidentialCarePackageId} already exists");
+            }
+
             var residentialCareBrokerageInfoEntity = residentialCareBrokerageInfoCreationDomain.ToDb();
             var res = await _residentialCareBrokerageGateway.CreateAsync(residentialCareBrokerageInfoEntity).ConfigureAwait(false);
             return res.ToResponse();

--- a/LBH.AdultSocialCare.Api/V1/UseCase/ResidentialCareUseCases/Concrete/ChangeStatusResidentialCarePackageUseCase.cs
+++ b/LBH.AdultSocialCare.Api/V1/UseCase/ResidentialCareUseCases/Concrete/ChangeStatusResidentialCarePackageUseCase.cs
@@ -8,6 +8,10 @@ using LBH.AdultSocialCare.Api.V1.Gateways.ResidentialCarePackageGateways;
 using LBH.AdultSocialCare.Api.V1.UseCase.ResidentialCareUseCases.Interfaces;
 using System;
 using System.Threading.Tasks;
+using Common.Exceptions.CustomExceptions;
+using LBH.AdultSocialCare.Api.V1.BusinessRules;
+using LBH.AdultSocialCare.Api.V1.Domain.ResidentialCarePackageDomains;
+using LBH.AdultSocialCare.Api.V1.Extensions;
 
 namespace LBH.AdultSocialCare.Api.V1.UseCase.ResidentialCareUseCases.Concrete
 {
@@ -28,6 +32,15 @@ namespace LBH.AdultSocialCare.Api.V1.UseCase.ResidentialCareUseCases.Concrete
 
         public async Task<ResidentialCarePackageResponse> UpdateAsync(Guid residentialCarePackageId, int statusId, string requestMoreInformation = null)
         {
+            var package = await _gateway.GetAsync(residentialCarePackageId).ConfigureAwait(false);
+
+            if (!PackageStatusTransitions.CanChangeStatus(package.StatusId, statusId))
+            {
+                throw new ApiException(
+                    "Cannot change status of nursing care package",
+                    detail: $"Cannot set status of the package {residentialCarePackageId} to '{ApprovalHistoryConstants.GetLogText(statusId)}' as it is already in status '{ApprovalHistoryConstants.GetLogText(package.StatusId)}'");
+            }
+
             var residentialCarePackageDomain = await _gateway.ChangeStatusAsync(residentialCarePackageId, statusId).ConfigureAwait(false);
             var userId = new Guid("1f825b5f-5c65-41fb-8d9e-9d36d78fd6d8");
             var user = await _usersGateway.GetAsync(userId).ConfigureAwait(false);


### PR DESCRIPTION
## Changes

- Error 500 on attempt to approve already approved nursing / residential care package
- Error 500 on attempt to create brokerage for package already having a brokerage
- Prevented duplicated history entries generation on repeated attempts to set the same package stage

Ticket [Check Nursing/Residential Package and prevent double approve and create brokerage](https://app.clickup.com/t/r4y0bq)