### PR TITLE
fixed duplicated invoice items generation for ad-hoc payruns

### DIFF
--- a/LBH.AdultSocialCare.Functions.Payruns/Services/InvoiceItemGenerators/BaseInvoiceItemsGenerator.cs
+++ b/LBH.AdultSocialCare.Functions.Payruns/Services/InvoiceItemGenerators/BaseInvoiceItemsGenerator.cs
@@ -33,7 +33,7 @@ namespace LBH.AdultSocialCare.Functions.Payruns.Services.InvoiceItemGenerators
             var latestInvoiceItem = GetLatestInvoiceItem(packageItem, packageInvoices);
 
             return latestInvoiceItem != null
-                ? Dates.Min(packageItem.EndDate, latestInvoiceItem.ToDate.AddDays(1))
+                ? latestInvoiceItem.ToDate.AddDays(1)
                 : Dates.Max(packageItem.StartDate, PayrunConstants.DefaultStartDate);
         }
 

--- a/Tests/LBH.AdultSocialCare.Functions.Payruns.Tests/Services/InvoiceItemGenerators/CarePackageDetailGeneratorWeeklyTests.cs
+++ b/Tests/LBH.AdultSocialCare.Functions.Payruns.Tests/Services/InvoiceItemGenerators/CarePackageDetailGeneratorWeeklyTests.cs
@@ -60,6 +60,16 @@ namespace LBH.AdultSocialCare.Functions.Payruns.Tests.Services.InvoiceItemGenera
         }
 
         [Fact]
+        public void ShouldSkipDetailsTotallyCoveredByInvoices()
+        {
+            PaymentExperiment
+                .For(_package, _generator)
+                .CreateInvoice("31-12-2022")
+                .CreateInvoice("31-12-2022")
+                .EnsureNoInvoiceGenerated();
+        }
+
+        [Fact]
         public void ShouldConsiderRejectedInvoices()
         {
             PaymentExperiment
@@ -90,7 +100,6 @@ namespace LBH.AdultSocialCare.Functions.Payruns.Tests.Services.InvoiceItemGenera
         }
 
         #endregion Normal finite weekly needs
-
 
         #region Refunds for finite details
 


### PR DESCRIPTION
## Changes

- fixed duplicated invoice item generation for finite package details / reclaims in ad-hoc payruns
